### PR TITLE
Apply DefaultRules before PlatformRules

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -29,8 +29,8 @@ class Config extends PhpCsFixerConfig
         $this->applyFinderFilter(new Filter\GitFilter($this->projectRoot));
         $this->applyFinderFilter(new Filter\DefaultFilter());
 
-        $this->applyRuleSet(new Rules\PlatformRules($this->projectRoot));
         $this->applyRuleSet(new Rules\DefaultRules());
+        $this->applyRuleSet(new Rules\PlatformRules($this->projectRoot));
     }
 
     public function getProjectRoot()


### PR DESCRIPTION
Workaround for cs-fixer-2.15.4 [adding array_syntax to `@Symfony` RuleSet](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4566)

Fixes #2