### PR TITLE
Add configure() method to add more customization

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -31,6 +31,15 @@ class Config extends PhpCsFixerConfig
 
         $this->applyRuleSet(new Rules\DefaultRules());
         $this->applyRuleSet(new Rules\PlatformRules($this->projectRoot));
+
+        $this->configure();
+    }
+
+    /**
+     * Method called from constructor to do extra configuration.
+     * To be overridden by a subclass.
+     */
+    protected function configure() {
     }
 
     public function getProjectRoot()


### PR DESCRIPTION
Projects that extend this project `Config` class could add more finder or rules configuration, without needing to know inner details of `__construct`.