### PR TITLE
Move Rules apply to configure

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -29,9 +29,6 @@ class Config extends PhpCsFixerConfig
         $this->applyFinderFilter(new Filter\GitFilter($this->projectRoot));
         $this->applyFinderFilter(new Filter\DefaultFilter());
 
-        $this->applyRuleSet(new Rules\DefaultRules());
-        $this->applyRuleSet(new Rules\PlatformRules($this->projectRoot));
-
         $this->configure();
     }
 
@@ -40,6 +37,8 @@ class Config extends PhpCsFixerConfig
      * To be overridden by a subclass.
      */
     protected function configure() {
+        $this->applyRuleSet(new Rules\DefaultRules());
+        $this->applyRuleSet(new Rules\PlatformRules($this->projectRoot));
     }
 
     public function getProjectRoot()


### PR DESCRIPTION
This allows skip them by subclassing.